### PR TITLE
Add category field to services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# GameHub
+
+This project is a simple marketplace for digital goods built with Flask and SQLAlchemy.
+
+## Database setup
+
+After cloning the repository, create the SQLite database using the `init_db.py` script:
+
+```bash
+python init_db.py
+```
+
+Running this script will remove any existing `instance/gamehub.db` file and create a fresh database with all tables.
+
+If you already had a previous version of the database, be aware that it will be deleted when running the script. Back up any important data before executing it.

--- a/init_db.py
+++ b/init_db.py
@@ -1,7 +1,13 @@
 from app import db, app, User, Service, Review, Order
+import os
+
+DB_PATH = os.path.join(app.instance_path, 'gamehub.db')
 
 if __name__ == '__main__':
     with app.app_context():
+        if os.path.exists(DB_PATH):
+            os.remove(DB_PATH)
+            print("🗑 Старый файл базы удалён")
         db.create_all()
         print("✅ Таблицы успешно созданы.")
 

--- a/templates/my_services.html
+++ b/templates/my_services.html
@@ -49,10 +49,11 @@
 			{% if services %}
 			<div class="product-list">
 				{% for s in services %}
-				<div class="product">
-					<h3>{{ s.title }}</h3>
-					<p>{{ s.description }}</p>
-					<p class="price">{{ s.price }} ₽</p>
+                                <div class="product">
+                                        <h3>{{ s.title }}</h3>
+                                        <p>{{ s.description }}</p>
+                                        <p class="details">Категория: {{ s.category }}</p>
+                                        <p class="price">{{ s.price }} ₽</p>
 					<!-- Здесь можно позже добавить кнопки “Редактировать” и “Удалить” -->
 				</div>
 				{% endfor %}


### PR DESCRIPTION
## Summary
- extend `Service` model with a `category` column
- allow specifying category when adding a service
- filter catalog by category and show selected value
- include category in seller's "My services" list
- recreate database automatically in `init_db.py`
- add basic README with DB setup instructions

## Testing
- `python -m py_compile app.py init_db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494d7624fc8328bc6a8423ef5257cc