### PR TITLE
Fix neon lines display

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -3,18 +3,49 @@
 /* === Общие стили === */
 html,
 body {
-	height: 100%;
-	margin: 0;
-	padding: 0;
-	display: flex;
-	flex-direction: column;
-	background-color: #2f2f2f; /* статичный самый тёмный серый */
-	color: #f0f0f0; /* светлый текст для тёмного фона */
-	font-family: Arial, sans-serif;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        color: #f0f0f0; /* светлый текст для тёмного фона */
+        font-family: Arial, sans-serif;
+}
+
+html {
+        background-color: #2f2f2f; /* тёмный фон */
 }
 
 body {
-	flex: 1;
+        flex: 1;
+        position: relative;
+}
+
+/* === Неоновые вертикальные линии в фоне === */
+body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: -1;
+        background-color: #2f2f2f;
+        background-image: repeating-linear-gradient(
+                to right,
+                rgba(0, 255, 255, 0.15) 0,
+                rgba(0, 255, 255, 0.15) 2px,
+                transparent 2px,
+                transparent 80px
+        );
+        animation: moveNeon 15s linear infinite;
+}
+
+@keyframes moveNeon {
+        from {
+                background-position: 0 0;
+        }
+        to {
+                background-position: 80px 0;
+        }
 }
 
 /* === Header и навигация === */


### PR DESCRIPTION
## Summary
- keep body background transparent so pseudo-element is visible
- apply base color directly to ::before element

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6849502dac988328893a4e3c11272506